### PR TITLE
feat(DAB): retry failed registrations 

### DIFF
--- a/magic_bridge/ic/src/magic_bridge/magic_bridge.did
+++ b/magic_bridge/ic/src/magic_bridge/magic_bridge.did
@@ -12,6 +12,6 @@ service : {
   create : (TokenType, vec nat) -> (Result);
   get_all_canisters : () -> (vec record { principal; principal });
   get_canister : (principal) -> (opt principal);
-  get_failed_canisters : () -> (vec record { principal; principal });
+  get_failed_registrations : () -> (vec record { principal; principal });
   flush_failed_registrations : () -> ();
 }

--- a/magic_bridge/ic/src/magic_bridge/magic_bridge.did
+++ b/magic_bridge/ic/src/magic_bridge/magic_bridge.did
@@ -12,4 +12,6 @@ service : {
   create : (TokenType, vec nat) -> (Result);
   get_all_canisters : () -> (vec record { principal; principal });
   get_canister : (principal) -> (opt principal);
+  get_failed_canisters : () -> (vec record { principal; principal });
+  flush_failed_registrations : () -> ();
 }

--- a/magic_bridge/ic/src/magic_bridge/src/api/dab.rs
+++ b/magic_bridge/ic/src/magic_bridge/src/api/dab.rs
@@ -17,6 +17,6 @@ async fn flush_failed_registrations() -> () {
 }
 
 #[update(name = "get_failed_registrations", guard = "is_authorized")]
-fn get_failed_registrations() -> Vec<(Principal, CreateCanisterParam)> {
+fn get_failed_registrations() -> Vec<(Principal, (CreateCanisterParam, u8))> {
   STATE.with(|s| s.get_failed_canisters())
 }

--- a/magic_bridge/ic/src/magic_bridge/src/api/dab.rs
+++ b/magic_bridge/ic/src/magic_bridge/src/api/dab.rs
@@ -1,0 +1,22 @@
+use ic_kit::Principal;
+use ic_kit::{macros::update};
+
+use crate::factory::CreateCanisterParam;
+use crate::{
+    magic::STATE, 
+    dab::retry_failed_canisters,
+};
+
+use crate::api::admin::is_authorized;
+
+#[update(name = "flush_failed_registrations", guard = "is_authorized")]
+async fn flush_failed_registrations() -> () {
+  let failed_canisters = STATE.with(|s| s.get_failed_canisters());
+  let retry_failed = retry_failed_canisters(failed_canisters).await;
+  STATE.with(|s| s.replace_failed_canisters(retry_failed));
+}
+
+#[update(name = "get_failed_registrations", guard = "is_authorized")]
+fn get_failed_registrations() -> Vec<(Principal, CreateCanisterParam)> {
+  STATE.with(|s| s.get_failed_canisters())
+}

--- a/magic_bridge/ic/src/magic_bridge/src/api/dab.rs
+++ b/magic_bridge/ic/src/magic_bridge/src/api/dab.rs
@@ -1,13 +1,12 @@
-use ic_kit::macros::update;
-use ic_kit::Principal;
-
 use crate::factory::CreateCanisterParam;
-use crate::types::RetryCount;
-use crate::{dab::retry_failed_canisters, magic::STATE};
+use ic_kit::{candid::candid_method, macros::update, Principal};
 
-use crate::api::admin::is_authorized;
+use crate::{
+    api::admin::is_authorized, dab::retry_failed_canisters, magic::STATE, types::RetryCount,
+};
 
 #[update(name = "flush_failed_registrations", guard = "is_authorized")]
+#[candid_method(update, rename = "flush_failed_registrations")]
 async fn flush_failed_registrations() -> () {
     let failed_canisters = STATE.with(|s| s.get_failed_canisters());
     let retry_failed = retry_failed_canisters(failed_canisters).await;
@@ -15,6 +14,7 @@ async fn flush_failed_registrations() -> () {
 }
 
 #[update(name = "get_failed_registrations", guard = "is_authorized")]
+#[candid_method(update, rename = "get_failed_registrations")]
 fn get_failed_registrations() -> Vec<(Principal, (CreateCanisterParam, RetryCount))> {
     STATE.with(|s| s.get_failed_canisters())
 }

--- a/magic_bridge/ic/src/magic_bridge/src/api/dab.rs
+++ b/magic_bridge/ic/src/magic_bridge/src/api/dab.rs
@@ -1,22 +1,20 @@
+use ic_kit::macros::update;
 use ic_kit::Principal;
-use ic_kit::{macros::update};
 
 use crate::factory::CreateCanisterParam;
-use crate::{
-    magic::STATE, 
-    dab::retry_failed_canisters,
-};
+use crate::types::RetryCount;
+use crate::{dab::retry_failed_canisters, magic::STATE};
 
 use crate::api::admin::is_authorized;
 
 #[update(name = "flush_failed_registrations", guard = "is_authorized")]
 async fn flush_failed_registrations() -> () {
-  let failed_canisters = STATE.with(|s| s.get_failed_canisters());
-  let retry_failed = retry_failed_canisters(failed_canisters).await;
-  STATE.with(|s| s.replace_failed_canisters(retry_failed));
+    let failed_canisters = STATE.with(|s| s.get_failed_canisters());
+    let retry_failed = retry_failed_canisters(failed_canisters).await;
+    STATE.with(|s| s.replace_failed_canisters(retry_failed));
 }
 
 #[update(name = "get_failed_registrations", guard = "is_authorized")]
-fn get_failed_registrations() -> Vec<(Principal, (CreateCanisterParam, u8))> {
-  STATE.with(|s| s.get_failed_canisters())
+fn get_failed_registrations() -> Vec<(Principal, (CreateCanisterParam, RetryCount))> {
+    STATE.with(|s| s.get_failed_canisters())
 }

--- a/magic_bridge/ic/src/magic_bridge/src/api/mod.rs
+++ b/magic_bridge/ic/src/magic_bridge/src/api/mod.rs
@@ -4,3 +4,4 @@ mod get_canister;
 mod init;
 mod inspect_message;
 mod upgrade;
+mod dab;

--- a/magic_bridge/ic/src/magic_bridge/src/dab.rs
+++ b/magic_bridge/ic/src/magic_bridge/src/dab.rs
@@ -7,7 +7,7 @@ use std::str::FromStr;
 use crate::factory::CreateCanisterParam;
 use crate::{magic::STATE, types::*};
 
-const DAB_TOKEN_ADDRESS: &str = "xmt67-gqaaa-aaaaa-aahja-cai";
+const DAB_TOKEN_ADDRESS: &str = "ra3o4-ryaaa-aaaaa-aah6q-cai";
 const MAX_DAB_RETRIES: u8 = 10;
 
 #[derive(CandidType, Deserialize, Clone, PartialEq, Debug)]
@@ -52,7 +52,8 @@ pub async fn retry_failed_canisters(
     mut failed_canisters: Vec<(Principal, (CreateCanisterParam, RetryCount))>,
 ) -> Vec<(Principal, (CreateCanisterParam, RetryCount))> {
     let mut failed_retry_canisters = Vec::new();
-    for (canister_id, (params, retry_count)) in failed_canisters.drain(..) {
+    for (canister_id, (params, retry_count)) in failed_canisters {
+        // for (canister_id, (params, retry_count)) in failed_canisters.drain(..) {
         if retry_count >= MAX_DAB_RETRIES {
             failed_retry_canisters.push((canister_id, (params, retry_count)));
             continue;

--- a/magic_bridge/ic/src/magic_bridge/src/dab.rs
+++ b/magic_bridge/ic/src/magic_bridge/src/dab.rs
@@ -1,4 +1,4 @@
-use std::{str::{FromStr}, cell::RefCell, collections::HashMap};
+use std::{str::{FromStr}};
 use ic_kit::{
   candid::{ CandidType, Deserialize},
   Principal,
@@ -76,7 +76,7 @@ async fn register_dip20(canister_id: Principal, params: &CreateCanisterParam) ->
     let dab_args = DABParams {
         name: params.name.to_string(),
         description: "Wrapped Token from ETH".to_string(),
-        thumbnail: "https://terabethia.ooo/".to_string(),
+        thumbnail: params.logo.to_string(),
         frontend: Some("https://terabethia.ooo/".to_string()),
         principal_id: canister_id,
         details: details

--- a/magic_bridge/ic/src/magic_bridge/src/dab.rs
+++ b/magic_bridge/ic/src/magic_bridge/src/dab.rs
@@ -7,7 +7,7 @@ use std::str::FromStr;
 use crate::factory::CreateCanisterParam;
 use crate::{magic::STATE, types::*};
 
-const DAB_TOKEN_ADDRESS: &str = "ra3o4-ryaaa-aaaaa-aah6q-cai";
+const DAB_TOKEN_ADDRESS: &str = "eclat-5qaaa-aaaaa-aaica-cai";
 const MAX_DAB_RETRIES: u8 = 10;
 
 #[derive(CandidType, Deserialize, Clone, PartialEq, Debug)]
@@ -53,7 +53,6 @@ pub async fn retry_failed_canisters(
 ) -> Vec<(Principal, (CreateCanisterParam, RetryCount))> {
     let mut failed_retry_canisters = Vec::new();
     for (canister_id, (params, retry_count)) in failed_canisters {
-        // for (canister_id, (params, retry_count)) in failed_canisters.drain(..) {
         if retry_count >= MAX_DAB_RETRIES {
             failed_retry_canisters.push((canister_id, (params, retry_count)));
             continue;

--- a/magic_bridge/ic/src/magic_bridge/src/dab.rs
+++ b/magic_bridge/ic/src/magic_bridge/src/dab.rs
@@ -8,7 +8,7 @@ use ic_kit::{
 use crate::{types::*, magic::STATE};
 use crate::factory::{CreateCanisterParam};
 
-const DAB_TOKEN_ADDRESS: &str = "4sfmb-5yaaa-aaaaa-aagwq-cai";
+const DAB_TOKEN_ADDRESS: &str = "627te-pyaaa-aaaaa-aag2q-cai";
 
 
 #[derive(CandidType, Deserialize, Clone, PartialEq, Debug)]
@@ -44,40 +44,9 @@ pub enum OperationError {
 
 pub type DABResponse = Result<(), OperationError>;
 
-#[derive(CandidType, Deserialize, Default, Clone)]
-pub struct DABHistory {
-    pub registered_canisters: RefCell<Vec<Principal>>,
-    pub failed_canisters: RefCell<HashMap<Principal, CreateCanisterParam>>
-}
-
-impl DABHistory {
-    pub fn add_registered_canister(&mut self, canister_id: Principal) {
-        self.registered_canisters.borrow_mut().push(canister_id);
-    }
-
-    pub fn add_failed_canister(&mut self, canister_id: Principal, params: &CreateCanisterParam) {
-        self.failed_canisters.borrow_mut().insert(canister_id, params.clone());
-    }
-
-    pub fn canister_registered(&self, canister_id: &Principal) -> bool {
-        self.registered_canisters.borrow().contains(canister_id)
-    }
-
-    pub fn clear(&mut self) {
-        self.registered_canisters.borrow_mut().clear();
-        self.failed_canisters.borrow_mut().clear();
-    }
-}
-
-
 pub async fn register_canister(canister_id: Principal, params: &CreateCanisterParam) -> Result<Principal, OperationError> {
-    if STATE.with(|s| s.canister_registered(canister_id)) {
-        return Ok(canister_id);
-    }
-
     match call_dab(canister_id, &params).await {
         Ok(_) => {
-            STATE.with(|s| s.add_registered_canister(canister_id));
             return Ok(canister_id)
         },
         Err(op_error) => {

--- a/magic_bridge/ic/src/magic_bridge/src/dab.rs
+++ b/magic_bridge/ic/src/magic_bridge/src/dab.rs
@@ -8,7 +8,7 @@ use ic_kit::{
 use crate::{types::*, magic::STATE};
 use crate::factory::{CreateCanisterParam};
 
-const DAB_TOKEN_ADDRESS: &str = "627te-pyaaa-aaaaa-aag2q-cai";
+const DAB_TOKEN_ADDRESS: &str = "vdiho-ziaaa-aaaaa-aahfq-cai";
 
 
 #[derive(CandidType, Deserialize, Clone, PartialEq, Debug)]
@@ -44,6 +44,23 @@ pub enum OperationError {
 
 pub type DABResponse = Result<(), OperationError>;
 
+/*
+    Try to register all canisters given in the failed_canisters parameter.
+    Returns a vector of canisters that failed to register.    
+*/
+pub async fn retry_failed_canisters(
+    mut failed_canisters: Vec<(Principal, CreateCanisterParam)>
+    ) -> Vec<(Principal, CreateCanisterParam)>  {
+        let mut failed_retry_canisters = Vec::new();
+        for (canister_id, params) in failed_canisters.drain(..) {
+            if let Err(_e) = call_dab(canister_id, &params).await {
+                failed_retry_canisters.push((canister_id, params));
+            }
+        }
+        failed_retry_canisters
+    }
+
+
 pub async fn register_canister(canister_id: Principal, params: &CreateCanisterParam) -> Result<Principal, OperationError> {
     match call_dab(canister_id, &params).await {
         Ok(_) => {
@@ -75,8 +92,8 @@ async fn register_dip20(canister_id: Principal, params: &CreateCanisterParam) ->
 
     let dab_args = DABParams {
         name: params.name.to_string(),
-        description: "Wrapped Token from ETH".to_string(),
-        thumbnail: params.logo.to_string(),
+        description: "Wrapped Token from Ethereum network".to_string(),
+        thumbnail: "https://terabethia.ooo/".to_string(),
         frontend: Some("https://terabethia.ooo/".to_string()),
         principal_id: canister_id,
         details: details

--- a/magic_bridge/ic/src/magic_bridge/src/dab.rs
+++ b/magic_bridge/ic/src/magic_bridge/src/dab.rs
@@ -1,0 +1,136 @@
+use std::{str::{FromStr}, cell::RefCell, collections::HashMap};
+use ic_kit::{
+  candid::{ CandidType, Deserialize},
+  Principal,
+  ic,
+};
+
+use crate::types::*;
+use crate::factory::{CreateCanisterParam};
+
+const DAB_TOKEN_ADDRESS: &str = "zs2mv-bqaaa-aaaaa-aagla-cai";
+
+
+#[derive(CandidType, Deserialize, Clone, PartialEq, Debug)]
+pub enum DetailValue {
+    True,
+    False,
+    U64(u64),
+    I64(i64),
+    Float(f64),
+    Text(String),
+    Principal(Principal),
+    #[serde(with = "serde_bytes")]
+    Slice(Vec<u8>),
+    Vec(Vec<DetailValue>),
+}
+#[derive(CandidType, Deserialize)]
+pub struct DABParams {
+    pub name: String,
+    pub description: String,
+    pub thumbnail: String,
+    pub frontend: Option<String>,
+    pub principal_id: CanisterId,
+    pub details: Vec<(String, DetailValue)>,
+}
+
+#[derive(CandidType, Debug, Deserialize)]
+pub enum OperationError {
+    NotAuthorized,
+    NonExistentItem,
+    BadParameters,
+    Unknown(String),
+}
+
+pub type DABResponse = Result<(), OperationError>;
+
+#[derive(CandidType, Deserialize, Default, Clone)]
+pub struct DABHistory {
+    pub registered_canisters: RefCell<Vec<Principal>>,
+    pub failed_canisters: RefCell<HashMap<Principal, CreateCanisterParam>>
+}
+
+impl DABHistory {
+    pub fn add_registered_canister(&mut self, canister_id: Principal) {
+        self.registered_canisters.borrow_mut().push(canister_id);
+    }
+
+    pub fn add_failed_canister(&mut self, canister_id: Principal, params: &CreateCanisterParam) {
+        self.failed_canisters.borrow_mut().insert(canister_id, params.clone());
+    }
+}
+  
+
+
+pub async fn register_canister(canister_id: Principal, params: &CreateCanisterParam) -> Result<Principal, OperationError> {
+    let ic_stored_registry = ic::get_mut::<DABHistory>();
+    if ic_stored_registry.registered_canisters.borrow().contains(&canister_id){
+        return Ok(canister_id)
+    }
+
+    match call_dab(canister_id, &params).await {
+        Ok(_) => {
+            add_registered_canister(canister_id);
+            return Ok(canister_id)
+        },
+        Err(op_error) => {
+            add_failed_canister(canister_id, params);
+            return Err(op_error)
+        },
+    }
+}
+
+fn add_registered_canister(canister_id: Principal) {
+    let ic_stored_registry = ic::get_mut::<DABHistory>();
+    ic_stored_registry.add_registered_canister(canister_id);
+}
+
+fn add_failed_canister(canister_id: Principal, params: &CreateCanisterParam){
+    let ic_stored_registry = ic::get_mut::<DABHistory>();
+    ic_stored_registry.add_failed_canister(canister_id, params);
+}
+
+async fn call_dab(canister_id: Principal, params: &CreateCanisterParam) -> Result<(), OperationError> {
+    let result: Result<(), OperationError> = match params.token_type {
+        TokenType::DIP20 => register_dip20(canister_id, params).await,
+        TokenType::DIP721 => register_dip721(canister_id, params).await,
+    };
+  
+    result
+}
+
+async fn register_dip20(canister_id: Principal, params: &CreateCanisterParam) -> Result <(), OperationError> {
+    let dab_tokens_address = ic_kit::Principal::from_str(&DAB_TOKEN_ADDRESS).unwrap();
+
+    let details = vec![("symbol".to_string(), DetailValue::Text(params.symbol.to_string())), 
+                                                ("standard".to_string(), DetailValue::Text(String::from("DIP20"))),
+                                                ("total_supply".to_string(), DetailValue::U64(u64::from_str(&params.total_supply.to_string()).unwrap())),
+                                                ("verified".to_string(), DetailValue::True)];
+
+    let dab_args = DABParams {
+        name: params.name.to_string(),
+        description: "Wrapped Token from ETH".to_string(),
+        thumbnail: "https://terabethia.ooo/".to_string(),
+        frontend: Some("https://terabethia.ooo/".to_string()),
+        principal_id: canister_id,
+        details: details
+    };
+  
+    let canister_call: (DABResponse,) = 
+        match ic::call(dab_tokens_address, "add", (dab_args,)).await {
+            Ok(res) => res,
+            Err((code, err)) => {
+                return Err(OperationError::Unknown(format!("RejectionCode: {:?}\n{}", code, err)))
+        }
+    };
+
+    match canister_call {
+        (Ok(_),) => return Ok(()),
+        (Err(error),) => return Err(error),
+    }
+}
+
+async fn register_dip721(_canister_id: Principal, _params: &CreateCanisterParam) -> Result<(),OperationError> {
+  // TODO
+  return Ok(())
+}

--- a/magic_bridge/ic/src/magic_bridge/src/factory.rs
+++ b/magic_bridge/ic/src/magic_bridge/src/factory.rs
@@ -1,4 +1,4 @@
-use crate::{types::*, dab::{register_canister}};
+use crate::{dab::register_canister, types::*};
 use ic_kit::{
     candid::{encode_args, CandidType, Deserialize, Nat},
     ic,

--- a/magic_bridge/ic/src/magic_bridge/src/factory.rs
+++ b/magic_bridge/ic/src/magic_bridge/src/factory.rs
@@ -1,4 +1,4 @@
-use crate::types::*;
+use crate::{types::*, dab::{register_canister}};
 use ic_kit::{
     candid::{encode_args, CandidType, Deserialize, Nat},
     ic,
@@ -55,7 +55,7 @@ impl FromNat for Principal {
 
 // }
 
-#[derive(CandidType, Deserialize)]
+#[derive(CandidType, Deserialize, Clone)]
 pub struct CreateCanisterParam {
     pub logo: String,
     pub name: String,
@@ -105,6 +105,8 @@ impl Factory {
             param.owner,
             "only the owner of this contract can call the create method"
         );
+
+        let dab_params = param.clone();
 
         // create canister
         param.insert_controller(ic::id());
@@ -191,6 +193,11 @@ impl Factory {
         {
             return Err(FactoryError::InstallCodeError);
         }
+
+        // we dont care about this result because retry logic is being handled by dab module
+        ic_cdk::spawn(async move {
+            let _ = register_canister(canister_id, &dab_params).await;
+        });
 
         Ok(canister_id)
     }

--- a/magic_bridge/ic/src/magic_bridge/src/magic.rs
+++ b/magic_bridge/ic/src/magic_bridge/src/magic.rs
@@ -59,6 +59,20 @@ impl MagicState {
             .insert(canister_id, params.clone());
     }
     
+    pub fn get_failed_canisters(&self) -> Vec<(Principal, CreateCanisterParam)> {
+        self.failed_registration_canisters.borrow_mut().clone().into_iter().collect::<_>()
+    }
+
+    pub fn replace_failed_canisters(
+        &self,
+        failed_canisters: Vec<(Principal, CreateCanisterParam)>
+    ) {
+        self.failed_registration_canisters.replace(HashMap::new());
+        for (canister_id, params) in failed_canisters {
+            self.add_failed_canister(canister_id, &params);
+        }
+    }
+
     pub async fn _update_settings(
         args: UpdateSettingsArgument,
     ) -> Result<(), (RejectionCode, String)> {

--- a/magic_bridge/ic/src/magic_bridge/src/magic.rs
+++ b/magic_bridge/ic/src/magic_bridge/src/magic.rs
@@ -22,14 +22,15 @@ thread_local! {
 pub struct MagicState {
     pub canisters: RefCell<HashMap<EthereumAddr, CanisterId>>,
     pub controllers: RefCell<Vec<Principal>>,
-    pub failed_registration_canisters: RefCell<HashMap<Principal, (CreateCanisterParam, u8)>>,
+    pub failed_registration_canisters:
+        RefCell<HashMap<Principal, (CreateCanisterParam, RetryCount)>>,
 }
 
 #[derive(CandidType, Deserialize, Default)]
 pub struct StableMagicState {
     canisters: HashMap<EthereumAddr, CanisterId>,
     controllers: Vec<Principal>,
-    failed_registration_canisters: HashMap<Principal, (CreateCanisterParam, u8)>,
+    failed_registration_canisters: HashMap<Principal, (CreateCanisterParam, RetryCount)>,
 }
 
 impl MagicState {
@@ -53,20 +54,24 @@ impl MagicState {
         &self,
         canister_id: Principal,
         params: &CreateCanisterParam,
-        retry_count: u8,
+        retry_count: RetryCount,
     ) {
         self.failed_registration_canisters
             .borrow_mut()
             .insert(canister_id, (params.clone(), retry_count));
     }
-    
-    pub fn get_failed_canisters(&self) -> Vec<(Principal, (CreateCanisterParam, u8))> {
-        self.failed_registration_canisters.borrow_mut().clone().into_iter().collect::<_>()
+
+    pub fn get_failed_canisters(&self) -> Vec<(Principal, (CreateCanisterParam, RetryCount))> {
+        self.failed_registration_canisters
+            .borrow_mut()
+            .clone()
+            .into_iter()
+            .collect::<_>()
     }
 
     pub fn replace_failed_canisters(
         &self,
-        failed_canisters: Vec<(Principal, (CreateCanisterParam, u8))>
+        failed_canisters: Vec<(Principal, (CreateCanisterParam, RetryCount))>,
     ) {
         self.failed_registration_canisters.replace(HashMap::new());
         for (canister_id, params) in failed_canisters {

--- a/magic_bridge/ic/src/magic_bridge/src/magic.rs
+++ b/magic_bridge/ic/src/magic_bridge/src/magic.rs
@@ -1,4 +1,6 @@
+use crate::factory::CreateCanisterParam;
 use crate::types::*;
+use crate::dab::DABHistory;
 use ic_kit::candid::{CandidType, Deserialize};
 use ic_kit::interfaces::management::{
     CanisterStatus, CanisterStatusResponse, DeleteCanister, DepositCycles, InstallCode,
@@ -21,12 +23,14 @@ thread_local! {
 pub struct MagicState {
     pub canisters: RefCell<HashMap<EthereumAddr, CanisterId>>,
     pub controllers: RefCell<Vec<Principal>>,
+    pub dab_registration_history: RefCell<DABHistory>,
 }
 
 #[derive(CandidType, Deserialize, Default)]
 pub struct StableMagicState {
     canisters: HashMap<EthereumAddr, CanisterId>,
     controllers: Vec<Principal>,
+    dab_registration_history: DABHistory,
 }
 
 impl MagicState {
@@ -44,6 +48,26 @@ impl MagicState {
         canister_id: CanisterId,
     ) -> Option<CanisterId> {
         self.canisters.borrow_mut().insert(eth_addr, canister_id)
+    }
+
+    pub fn canister_registered(&self, canister_id: CanisterId) -> bool {
+        self.dab_registration_history
+            .borrow()
+            .canister_registered(&canister_id)
+    }
+
+    pub fn add_registered_canister(&self, canister_id: CanisterId) {
+        self.dab_registration_history.borrow_mut().add_registered_canister(canister_id);
+    }
+
+    pub fn add_failed_canister(
+        &self,
+        canister_id: CanisterId,
+        params: &CreateCanisterParam,
+    ) {
+        self.dab_registration_history
+            .borrow_mut()
+            .add_failed_canister(canister_id, params);
     }
 
     pub async fn _update_settings(
@@ -130,16 +154,19 @@ impl MagicState {
         StableMagicState {
             canisters: self.canisters.take(),
             controllers: self.controllers.take(),
+            dab_registration_history: self.dab_registration_history.take(),
         }
     }
 
     pub fn clear_all(&self) {
         self.canisters.borrow_mut().clear();
         self.controllers.borrow_mut().clear();
+        self.dab_registration_history.borrow_mut().clear();
     }
 
     pub fn replace_all(&self, stable_magic_state: StableMagicState) {
         self.canisters.replace(stable_magic_state.canisters);
         self.controllers.replace(stable_magic_state.controllers);
+        self.dab_registration_history.replace(stable_magic_state.dab_registration_history);
     }
 }

--- a/magic_bridge/ic/src/magic_bridge/src/main.rs
+++ b/magic_bridge/ic/src/magic_bridge/src/main.rs
@@ -2,6 +2,7 @@ mod api;
 mod factory;
 mod magic;
 mod types;
+mod dab;
 
 #[cfg(any(target_arch = "wasm32", test))]
 fn main() {}

--- a/magic_bridge/ic/src/magic_bridge/src/main.rs
+++ b/magic_bridge/ic/src/magic_bridge/src/main.rs
@@ -1,14 +1,15 @@
 mod api;
+mod dab;
 mod factory;
 mod magic;
 mod types;
-mod dab;
 
 #[cfg(any(target_arch = "wasm32", test))]
 fn main() {}
 
 #[cfg(not(any(target_arch = "wasm32", test)))]
 fn main() {
+    use crate::factory::CreateCanisterParam;
     use ic_kit::candid;
     use ic_kit::candid::Nat;
     use ic_kit::Principal;

--- a/magic_bridge/ic/src/magic_bridge/src/types.rs
+++ b/magic_bridge/ic/src/magic_bridge/src/types.rs
@@ -4,6 +4,8 @@ pub type EthereumAddr = Principal;
 
 pub type CanisterId = Principal;
 
+pub type RetryCount = u8;
+
 pub type MagicResponse = Result<Principal, FactoryError>;
 
 #[derive(CandidType, Deserialize, Clone, Copy)]


### PR DESCRIPTION
# Description
Retry failed calls to DAB performed from the magic_bridge

## Feat
 - Define a candid method that triggers a flush of failed_canisters list calling DAB again in order to get the new canisters registered.
 - If the call fails again, a counter is incremented in order to be able to have track of the amount of times that the canister have been retried