### PR TITLE
chore: gas optimizations on terabethia contract

### DIFF
--- a/core/eth/contracts/Terabethia.sol
+++ b/core/eth/contracts/Terabethia.sol
@@ -67,27 +67,26 @@ contract Terabethia is Initializable, ITerabethiaCore {
         external
         returns (bytes32)
     {
-        simpleStorage().nonce += 1;
+        unchecked {
+            simpleStorage().nonce += 1;
+        }
+
+        uint256 nonce = simpleStorage().nonce;
 
         bytes32 msgHash = keccak256(
             abi.encodePacked(
                 uint256(uint160(msg.sender)),
                 to_address,
-                simpleStorage().nonce,
+                nonce,
                 payload.length,
                 payload
             )
         );
 
-        simpleStorage().messages[msgHash] += 1;
+        simpleStorage().messages[msgHash] = 1;
 
         // we only emit event, so we can auto-trigger message consumption on the IC
-        emit LogMessageToL2(
-            msg.sender,
-            to_address,
-            simpleStorage().nonce,
-            payload
-        );
+        emit LogMessageToL2(msg.sender, to_address, nonce, payload);
 
         return msgHash;
     }


### PR DESCRIPTION
Open Zeppling notes:

Once `simpleStorage().messages[msgHash]` is assigned to 1. Consider setting `simpleStorage().messages[msgHash]` to zero to show the message has been consumed on the L2.

-Gas optimizations within sendMessage function w/ ~500 gas savings in total:
--cache `simpleStorage().nonce` to avoid performing multiple SLOADS

--use unchecked math when incrementing `simpleStorage().nonce`, overflow unrealistic. if this contract were called 100 trillion times a day for 100 years we would still not be close to overflow. overflow can and should be monitored outside of the contract.

--don't increment `simpleStorage().messages[msgHash]`. instead, assign to 1 to save gas. There's never a situation where this value is anything other than 1 or 0 because the nonce is used when encoding the message hash. The message hash will never be repeated.

- [ ] testing
- [ ] deploy