### PR TITLE
fix: removing padding from bytes array

### DIFF
--- a/magic_bridge/ic/src/dip20_proxy/src/proxy.rs
+++ b/magic_bridge/ic/src/dip20_proxy/src/proxy.rs
@@ -176,7 +176,7 @@ impl FromNat for Principal {
         let be_bytes = input.0.to_bytes_be();
         let be_bytes_len = be_bytes.len();
         let padding_bytes = if be_bytes_len > 10 && be_bytes_len < 29 {
-            29 - be_bytes_len
+            0
         } else if be_bytes_len < 10 {
             10 - be_bytes_len
         } else {
@@ -198,6 +198,7 @@ mod tests {
     };
 
     use super::*;
+    use candid::{types::ic_types::principal, Int};
     use ic_kit::mock_principals;
 
     #[test]
@@ -409,6 +410,19 @@ mod tests {
         assert_eq!(
             erc20_addr_pid.to_string(),
             "6iiev-lyvwz-q7nu7-5tj7n-r3kmr-c6m7u-kumzc-eipy"
+        );
+    }
+
+    #[test]
+    fn test_principal_from_nat() {
+        let eth_address_as_nat =
+            Nat::from_str("1118288024408649503359660893691376548931478070077").unwrap();
+
+        let principal = Principal::from_nat(eth_address_as_nat.clone());
+
+        assert_eq!(
+            principal.to_string(),
+            String::from("tiip2-ood4h-cpenr-chacl-abhlj-7scey-usvbm-2gpi")
         );
     }
 

--- a/magic_bridge/ic/src/magic_bridge/src/factory.rs
+++ b/magic_bridge/ic/src/magic_bridge/src/factory.rs
@@ -20,7 +20,7 @@ impl FromNat for Principal {
         let be_bytes = input.0.to_bytes_be();
         let be_bytes_len = be_bytes.len();
         let padding_bytes = if be_bytes_len > 10 && be_bytes_len < 29 {
-            29 - be_bytes_len
+            0
         } else if be_bytes_len < 10 {
             10 - be_bytes_len
         } else {
@@ -200,5 +200,24 @@ impl Factory {
         });
 
         Ok(canister_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_principal_from_nat() {
+        let eth_address_as_nat =
+            Nat::from_str("1118288024408649503359660893691376548931478070077").unwrap();
+
+        let principal = Principal::from_nat(eth_address_as_nat.clone());
+
+        assert_eq!(
+            principal.to_string(),
+            String::from("tiip2-ood4h-cpenr-chacl-abhlj-7scey-usvbm-2gpi")
+        );
     }
 }


### PR DESCRIPTION
## Description 

## Fix
 - `Principal::from_nat` add new test and now it returns the same as Principal::fromHex() in js library 

⚠️  when using an existing token, the magic bridge will create a new canister because from_nat of the address will now be correct