### PR TITLE
chore: change nonce type to [u8;32] in consume_message fn

### DIFF
--- a/core/ic/src/tera/src/api/consume_message.rs
+++ b/core/ic/src/tera/src/api/consume_message.rs
@@ -4,7 +4,7 @@ use ic_kit::ic::caller;
 
 use crate::{
     common::{
-        types::{ConsumeMessageResponse, IncomingMessageHashParams, Message},
+        types::{ConsumeMessageResponse, IncomingMessageHashParams, Message, NonceBytes},
         utils::Keccak256HashFn,
     },
     tera::{ToNat, STATE},
@@ -12,7 +12,7 @@ use crate::{
 
 #[update(name = "consume_message")]
 #[candid_method(update, rename = "consume_message")]
-fn consume(from: Principal, nonce_bytes: [u8; 32], payload: Vec<Nat>) -> ConsumeMessageResponse {
+fn consume(from: Principal, nonce_bytes: NonceBytes, payload: Vec<Nat>) -> ConsumeMessageResponse {
     let nonce = nonce_bytes.to_nat();
     let nonce_exists = STATE.with(|s| s.nonce_exists(&nonce));
     if nonce_exists {
@@ -68,7 +68,7 @@ mod tests {
 
     use super::*;
 
-    fn bytes_from_nat(number: Nat) -> [u8; 32] {
+    fn bytes_from_nat(number: Nat) -> NonceBytes {
         let nonce = number.0.to_bytes_be();
         let be_bytes_len = nonce.len();
         let padding_bytes = 32 - be_bytes_len;
@@ -85,7 +85,7 @@ mod tests {
 
     fn concume_message_with_nonce(
         mock_ctx: &mut MockContext,
-        nonce: [u8; 32],
+        nonce: NonceBytes,
     ) -> ConsumeMessageResponse {
         // originating eth address as pid
         let from = mock_principals::john();

--- a/core/ic/src/tera/src/common/types.rs
+++ b/core/ic/src/tera/src/common/types.rs
@@ -2,6 +2,7 @@ use ic_kit::candid::{CandidType, Deserialize, Nat};
 use serde::Serialize;
 
 pub type Nonce = Nat;
+pub type NonceBytes = [u8; 32];
 
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct ConsumeMessageResponse(pub(crate) Result<bool, String>);

--- a/core/ic/src/tera/src/tera.rs
+++ b/core/ic/src/tera/src/tera.rs
@@ -1,4 +1,4 @@
-use crate::common::types::{Nonce, OutgoingMessage, OutgoingMessagePair};
+use crate::common::types::{Nonce, NonceBytes, OutgoingMessage, OutgoingMessagePair};
 use candid::{CandidType, Deserialize, Nat, Principal};
 use ic_kit::ic::caller;
 use sha2::{Digest, Sha256};
@@ -93,7 +93,7 @@ pub trait ToNat {
     fn to_nat(&self) -> Nat;
 }
 
-impl ToNat for [u8; 32] {
+impl ToNat for NonceBytes {
     fn to_nat(&self) -> Nat {
         Nat::from(num_bigint::BigUint::from_bytes_be(&self.as_slice()[..]))
     }

--- a/core/ic/src/tera/src/tera.rs
+++ b/core/ic/src/tera/src/tera.rs
@@ -93,6 +93,12 @@ pub trait ToNat {
     fn to_nat(&self) -> Nat;
 }
 
+impl ToNat for [u8; 32] {
+    fn to_nat(&self) -> Nat {
+        Nat::from(num_bigint::BigUint::from_bytes_be(&self.as_slice()[..]))
+    }
+}
+
 impl ToNat for Principal {
     #[inline(always)]
     fn to_nat(&self) -> Nat {

--- a/core/ic/src/tera/tera.did
+++ b/core/ic/src/tera/tera.did
@@ -6,7 +6,7 @@ type SendMessageResponse = variant { Ok : OutgoingMessage; Err : text };
 type StoreMessageResponse = variant { Ok : CallResult; Err : text };
 service : {
   authorize : (principal) -> ();
-  consume_message : (principal, nat, vec nat) -> (ConsumeMessageResponse);
+  consume_message : (principal, vec nat8, vec nat) -> (ConsumeMessageResponse);
   get_messages : () -> (vec OutgoingMessagePair) query;
   get_nonces : () -> (vec nat) query;
   remove_messages : (vec OutgoingMessagePair) -> (ConsumeMessageResponse);


### PR DESCRIPTION
# Description 

## Changes
 - Change nonce type in `consume_message` canister method from `Nat` to `[u8; 32]`
 - implement `ToNat` for `[u8;32]` 
