### PR TITLE
chore: upgrade ic_cdk

### DIFF
--- a/core/ic/Cargo.lock
+++ b/core/ic/Cargo.lock
@@ -178,16 +178,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
-name = "base32"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ce669cd6c8588f79e15cf450314f9638f967fc5770ff1c7c1deb0925ea7cfa"
-
-[[package]]
 name = "beef"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bed554bd50246729a1ec158d08aa3235d1b69d94ad120ebe187e28894787e736"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "binread"
@@ -292,9 +295,9 @@ checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
 
 [[package]]
 name = "candid"
-version = "0.7.8"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7577605c33073dcafc17a5ed6373aa0cb7005e7d4e4b7cd40ca01cb2385533"
+checksum = "a4f5cdd24185c6d6edba09bcfe06cf9c1e7fd579cbe5e4ae2dffba9c474a5a7f"
 dependencies = [
  "anyhow",
  "binread",
@@ -371,9 +374,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.2.2"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3825b1e8580894917dc4468cb634a1b4e9745fddc854edad72d9c04644c0319f"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
 ]
@@ -412,6 +415,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
 name = "derivative"
@@ -674,9 +683,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "ic-cdk"
-version = "0.3.3"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "606276ed1ce363eb9ccaf492e36fb40425417dcd4598f261d47e0ed6a1309faa"
+checksum = "141341c2cb26c4e5f196d5b64305c677b1abebe093eefbe2c622b4a2e6de8a9f"
 dependencies = [
  "candid",
  "cfg-if",
@@ -685,9 +694,9 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk-macros"
-version = "0.3.3"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bac2578a4779c3ae6d24c766ec7127872d73f29a9e7d70b6607a2fdedd0dde"
+checksum = "a5196f57df320b206129d4aae96a0cea72ea2759a5c82651bbb60d721f834998"
 dependencies = [
  "candid",
  "ic-cdk",
@@ -700,30 +709,46 @@ dependencies = [
 
 [[package]]
 name = "ic-kit"
-version = "0.4.3"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0d4a05326865a582add1d6bcdec2b5d2af0415a12f6ef2431f3e93e52c347a"
+checksum = "a5f1be26d1d7c53c51e7291475d41773f4d86b7f67599d3beae8fd375e095fa0"
 dependencies = [
  "async-std",
+ "bincode",
+ "candid",
  "futures",
  "ic-cdk",
- "ic-cdk-macros",
+ "ic-kit-macros",
  "serde",
  "serde_bytes",
 ]
 
 [[package]]
-name = "ic-types"
-version = "0.2.2"
+name = "ic-kit-macros"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2c021c11ae1d716f45d783f5764f418a11f12aea1fdc4fc8a2b2242e0dae708"
+checksum = "6e99841e2325318b376bdfa3185818dd0864aa5f0723c4b9c45c71d334b34c1d"
 dependencies = [
- "base32",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_tokenstream",
+ "syn",
+]
+
+[[package]]
+name = "ic-types"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e9cac29df1f2906137c327ed24dfc398460eda054abaa6107273c11afe6384"
+dependencies = [
  "crc32fast",
+ "data-encoding",
  "hex",
  "serde",
  "serde_bytes",
- "sha2 0.9.8",
+ "sha2",
  "thiserror",
 ]
 
@@ -1179,19 +1204,6 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "sha2"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99c3bd8169c58782adad9290a9af5939994036b76187f7b4f0e6de91dbbfc0ec"
@@ -1278,7 +1290,7 @@ dependencies = [
  "num-bigint",
  "serde",
  "serde_bytes",
- "sha2 0.10.1",
+ "sha2",
  "sha3",
 ]
 

--- a/core/ic/Cargo.lock
+++ b/core/ic/Cargo.lock
@@ -295,9 +295,9 @@ checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
 
 [[package]]
 name = "candid"
-version = "0.7.15"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4f5cdd24185c6d6edba09bcfe06cf9c1e7fd579cbe5e4ae2dffba9c474a5a7f"
+checksum = "b7e4287605536419ac6ce9d76d3aa5733677ca8c7c2891079b2c71a345cc17a3"
 dependencies = [
  "anyhow",
  "binread",
@@ -918,6 +918,7 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -1173,9 +1174,9 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.5"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
+checksum = "cfc50e8183eeeb6178dcb167ae34a8051d63535023ae38b5d8d12beae193d37b"
 dependencies = [
  "serde",
 ]

--- a/core/ic/src/tera/Cargo.toml
+++ b/core/ic/src/tera/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/main.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-candid = "0.7.4"
+candid = "0.7.16"
 ic-cdk = "0.5.5"
 sha2 = "0.10.1"
 ic-cdk-macros = "0.5.5"

--- a/core/ic/src/tera/Cargo.toml
+++ b/core/ic/src/tera/Cargo.toml
@@ -10,10 +10,10 @@ crate-type = ["cdylib"]
 
 [dependencies]
 candid = "0.7.4"
-ic-cdk = "0.3.1"
+ic-cdk = "0.5.5"
 sha2 = "0.10.1"
-ic-cdk-macros = "0.3"
-ic-kit = "0.4.3"
+ic-cdk-macros = "0.5.5"
+ic-kit = "0.4.8"
 sha3 = "0.9.1"
 hex = "0.4.3"
 serde = "1.0.130"

--- a/core/ic/src/tera/src/api/store_message.rs
+++ b/core/ic/src/tera/src/api/store_message.rs
@@ -1,6 +1,5 @@
-use candid::{candid_method, encode_args, Nat, Principal};
-use ic_cdk::api;
-use ic_cdk_macros::update;
+use candid::{candid_method, Nat, Principal};
+use ic_kit::macros::update;
 
 use super::admin::is_authorized;
 use crate::{
@@ -40,9 +39,9 @@ async fn trigger_call(
         return StoreMessageResponse(Err(message_exists.err().unwrap()));
     }
 
-    let args_raw = encode_args((&from, &nonce, &payload)).unwrap();
+    let args_raw = ic_kit::candid::encode_args((&from, &nonce, &payload)).unwrap();
 
-    match api::call::call_raw(to, "handle_message", &args_raw[..], 0).await {
+    match ic_kit::ic::call_raw(to, "handle_message", args_raw, 0).await {
         Ok(x) => StoreMessageResponse(Ok(CallResult { r#return: x })),
         Err((code, msg)) => StoreMessageResponse(Err(format!(
             "An error happened during the call: {}: {}",

--- a/core/ic/src/tera/src/api/store_message.rs
+++ b/core/ic/src/tera/src/api/store_message.rs
@@ -42,7 +42,7 @@ async fn trigger_call(
 
     let args_raw = encode_args((&from, &nonce, &payload)).unwrap();
 
-    match api::call::call_raw(to, "handle_message", args_raw, 0).await {
+    match api::call::call_raw(to, "handle_message", &args_raw[..], 0).await {
         Ok(x) => StoreMessageResponse(Ok(CallResult { r#return: x })),
         Err((code, msg)) => StoreMessageResponse(Err(format!(
             "An error happened during the call: {}: {}",


### PR DESCRIPTION
# Description
 - upgrade ic_cdk version
 - upgrade ic_cdk_madros version
 - upgrade ic-kit version
 
# Changes
 - Use ic-kit to perform intercanister call in trigger_call method

# Todo: 
 - Use ic-kit macros 
