### PR TITLE
Fix claimable messages

### DIFF
--- a/eth_bridge/ic/src/eth_proxy/src/proxy.rs
+++ b/eth_bridge/ic/src/eth_proxy/src/proxy.rs
@@ -99,8 +99,7 @@ impl ProxyState {
         eth_address: EthereumAddr,
         amount: Nat,
     ) -> Result<(), String> {
-        let eth_addr_hex = WETH_ADDRESS_ETH.trim_start_matches("0x");
-        let eth_addr_pid = Principal::from_slice(&hex::decode(eth_addr_hex).unwrap());
+        let eth_addr_pid = Principal::from_text(WETH_ADDRESS_IC).unwrap();
 
         let mut map = self.messages_unclaimed.borrow_mut();
         let messages = map
@@ -418,8 +417,6 @@ mod tests {
 
     #[test]
     fn test_claimable_messages() {
-        const WETH_ADDRESS_ETH: &str = "2e130e57021bb4dfb95eb4dd0dd8cfceb936148a";
-
         let eth_addr_1 = Principal::from_slice(
             &hex::decode("15B661f6D3FD9A7ED8Ed4c88bCcfD1546644443f").unwrap(),
         );
@@ -427,7 +424,7 @@ mod tests {
 
         let msg_hash_1 = String::from("123123123");
         let msg_key_2: [u8; 32] = [1; 32];
-        let token_id_1 = Principal::from_slice(&hex::decode(WETH_ADDRESS_ETH).unwrap());
+        let token_id_1 = Principal::from_text(WETH_ADDRESS_IC).unwrap();
         let amount_1 = Nat::from(1_u64);
 
         // first msg
@@ -480,14 +477,12 @@ mod tests {
 
     #[test]
     fn test_claimable_messages_with_different_amounts() {
-        const WETH_ADDRESS_ETH: &str = "2e130e57021bb4dfb95eb4dd0dd8cfceb936148a";
-
         let eth_addr_1 = Principal::from_slice(
             &hex::decode("15B661f6D3FD9A7ED8Ed4c88bCcfD1546644443f").unwrap(),
         );
         let msg_key_1: [u8; 32] = [0; 32];
         let msg_hash_1 = String::from("123123123");
-        let weth_principal = Principal::from_slice(&hex::decode(WETH_ADDRESS_ETH).unwrap());
+        let weth_principal = Principal::from_text(WETH_ADDRESS_IC).unwrap();
         let amount_1 = Nat::from(1_u64);
 
         let msg_key_2: [u8; 32] = [1; 32];

--- a/ledger/aws/serverless.yml
+++ b/ledger/aws/serverless.yml
@@ -133,7 +133,7 @@ functions:
       IC_IDENTITY: ${env:IC_IDENTITY}
       DIP20_PROXY_CANISTER_ID: ${env:DIP20_PROXY_CANISTER_ID}
       QUEUE_URL: !Ref ERC20TxWithdrawQueue
-      MAGIC_BRIDGE_CANISTER_ID: ${env.MAGIC_BRIDGE_CANISTER_ID}
+      MAGIC_BRIDGE_CANISTER_ID: ${env:MAGIC_BRIDGE_CANISTER_ID}
     events:
       - sqs:
           arn: !GetAtt

--- a/ledger/aws/src/functions/ethereum/dip20_proxy/removeClaimableCall.ts
+++ b/ledger/aws/src/functions/ethereum/dip20_proxy/removeClaimableCall.ts
@@ -20,6 +20,13 @@ const envs = requireEnv([
 // EthProxy ETH
 const provider = new ethers.providers.StaticJsonRpcProvider(envs.ETHEREUM_PROVIDER_URL);
 
+const principalArrayFromEthAddress = (ethAddress: string) => {
+  const arr = ethers.utils.arrayify(ethAddress);
+  const paddedArr = Array(29 - arr.length).fill(0);
+  const concat = new Uint8Array([...paddedArr, ...arr]);
+  return Principal.fromUint8Array(concat);
+}
+
 
 export const handleWithdraw = async (message: BlockNativePayload) => {
   if (message.status !== 'confirmed') {
@@ -52,7 +59,7 @@ export const handleWithdraw = async (message: BlockNativePayload) => {
 
   const amountAsNat = BigInt(transactionMetadata.payload.amount);
 
-  const tokenAddressPid = Principal.fromHex(transactionMetadata.payload.token.slice(2))
+  const tokenAddressPid = principalArrayFromEthAddress(transactionMetadata.payload.token);
   const dip20CanisterPid = await magicBridge.getPrincipal(tokenAddressPid);
   const dip20Principal = Principal.fromText(dip20CanisterPid.toString());
 
@@ -65,4 +72,5 @@ export const handleWithdraw = async (message: BlockNativePayload) => {
 };
 
 export const main = sqsHandler<BlockNativePayload>(handleWithdraw, envs.QUEUE_URL, undefined, 1);
+
 

--- a/ledger/aws/src/libs/dfinity/idls/dip20_proxy/dip20_proxy.d.ts
+++ b/ledger/aws/src/libs/dfinity/idls/dip20_proxy/dip20_proxy.d.ts
@@ -1,10 +1,8 @@
+import { ActorMethod } from "@dfinity/agent";
 import type { Principal } from "@dfinity/principal";
 
 export type RemoveClaimableResponse = { 'Ok': boolean } | { 'Err': string };
 
 export default interface _SERVICE {
-  'remove_claimable': (
-    arg_0: Principal, //ethAddress
-    arg_1: Principal, //tokenAddress
-    arg_2: bigint) => Promise<RemoveClaimableResponse>,
+  'remove_claimable': ActorMethod<[Principal, Principal, bigint], RemoveClaimableResponse>,
 }

--- a/ledger/aws/src/libs/dfinity/idls/dip20_proxy/dip20_proxy.did.ts
+++ b/ledger/aws/src/libs/dfinity/idls/dip20_proxy/dip20_proxy.did.ts
@@ -1,6 +1,6 @@
 export default ({ IDL }: { IDL: any }) => {
   const RemoveClaimableResponse = IDL.Variant({
-    Ok: IDL.bool,
+    Ok: IDL.Bool,
     Err: IDL.Text
   });
   return IDL.Service({

--- a/ledger/aws/src/libs/dfinity/idls/eth_proxy/eth.did.ts
+++ b/ledger/aws/src/libs/dfinity/idls/eth_proxy/eth.did.ts
@@ -1,6 +1,6 @@
 export default ({ IDL }: { IDL: any }) => {
   const RemoveClaimableResponse = IDL.Variant({
-    Ok: IDL.bool,
+    Ok: IDL.Bool,
     Err: IDL.Text
   });
   return IDL.Service({


### PR DESCRIPTION
# Description
 - Use weth canister id in claimable assets instead of weth_eth_address as principal
 - Fix candid on aws
 - Use magic bridge to fetch token canister id