### PR TITLE
chore: use update instead of query for get_messages method

### DIFF
--- a/core/aws/src/libs/dfinity/idls/tera/tera.did.ts
+++ b/core/aws/src/libs/dfinity/idls/tera/tera.did.ts
@@ -27,7 +27,7 @@ export default ({ IDL }: { IDL: any }) => {
       [ConsumeMessageResponse],
       [],
     ),
-    get_messages: IDL.Func([], [IDL.Vec(OutgoingMessagePair)], ['query']),
+    get_messages: IDL.Func([], [IDL.Vec(OutgoingMessagePair)], []),
     get_nonces: IDL.Func([], [IDL.Vec(IDL.Nat)], ['query']),
     remove_messages: IDL.Func(
       [IDL.Vec(OutgoingMessagePair)],

--- a/core/ic/src/tera/src/api/messages.rs
+++ b/core/ic/src/tera/src/api/messages.rs
@@ -1,5 +1,5 @@
 use candid::candid_method;
-use ic_cdk_macros::{query, update};
+use ic_cdk_macros::update;
 
 use super::admin::is_authorized;
 use crate::{
@@ -13,8 +13,8 @@ fn remove_messages(messages: Vec<OutgoingMessagePair>) -> RemoveMessagesResponse
     STATE.with(|s| RemoveMessagesResponse(s.remove_messages(messages)))
 }
 
-#[query(name = "get_messages", guard = "is_authorized")]
-#[candid_method(query, rename = "get_messages")]
+#[update(name = "get_messages", guard = "is_authorized")]
+#[candid_method(update, rename = "get_messages")]
 fn get_messages() -> Vec<OutgoingMessagePair> {
     STATE.with(|s| s.get_messages())
 }

--- a/core/ic/src/tera/tera.did
+++ b/core/ic/src/tera/tera.did
@@ -7,7 +7,7 @@ type StoreMessageResponse = variant { Ok : CallResult; Err : text };
 service : {
   authorize : (principal) -> ();
   consume_message : (principal, vec nat8, vec nat) -> (ConsumeMessageResponse);
-  get_messages : () -> (vec OutgoingMessagePair) query;
+  get_messages : () -> (vec OutgoingMessagePair);
   get_nonces : () -> (vec nat) query;
   remove_messages : (vec OutgoingMessagePair) -> (ConsumeMessageResponse);
   send_message : (principal, vec nat) -> (SendMessageResponse);


### PR DESCRIPTION
# Description 

Use update call instead of query for `get_messages` candid method on tera core. 

With this change now agent-js will check subnet signature on the response.