### PR TITLE
chore: validate slice len < 30 when call Principal::from_nat

### DIFF
--- a/core/ic/src/tera/src/main.rs
+++ b/core/ic/src/tera/src/main.rs
@@ -96,7 +96,7 @@ mod tests {
 
         assert_eq!(slice.len(), 28);
 
-        let p = Principal::from_nat(n);
+        let p = Principal::from_nat(n).unwrap();
 
         let p_expected = "kyxzn-5aawk-7tlkc-pvrag-fioax-rhyre-nev4e-4lyc6-ifk4v-zrvlm-sae";
 
@@ -111,7 +111,7 @@ mod tests {
 
         assert_eq!(slice.len(), 5);
 
-        let p = Principal::from_nat(n);
+        let p = Principal::from_nat(n).unwrap();
 
         let p_expected = "tcy4r-qaaaa-aaaab-qadyq-cai";
 

--- a/core/ic/src/tera/src/tera.rs
+++ b/core/ic/src/tera/src/tera.rs
@@ -107,14 +107,17 @@ impl ToNat for Principal {
 }
 
 pub trait FromNat {
-    fn from_nat(input: Nat) -> Principal;
+    fn from_nat(input: Nat) -> Result<Principal, String>;
 }
 
 impl FromNat for Principal {
     #[inline(always)]
-    fn from_nat(input: Nat) -> Principal {
+    fn from_nat(input: Nat) -> Result<Principal, String> {
         let be_bytes = input.0.to_bytes_be();
         let be_bytes_len = be_bytes.len();
+        if be_bytes_len > 29 {
+            return Err("Invalid Nat".to_string());
+        }
         let padding_bytes = if be_bytes_len > 10 && be_bytes_len < 29 {
             29 - be_bytes_len
         } else if be_bytes_len < 10 {
@@ -124,7 +127,7 @@ impl FromNat for Principal {
         };
         let mut p_slice = vec![0u8; padding_bytes];
         p_slice.extend_from_slice(&be_bytes);
-        Principal::from_slice(&p_slice)
+        Ok(Principal::from_slice(&p_slice))
     }
 }
 

--- a/eth_bridge/ic/src/eth_proxy/src/proxy.rs
+++ b/eth_bridge/ic/src/eth_proxy/src/proxy.rs
@@ -170,14 +170,17 @@ impl ToNat for Principal {
 }
 
 pub trait FromNat {
-    fn from_nat(input: Nat) -> Principal;
+    fn from_nat(input: Nat) -> Result<Principal, String>;
 }
 
 impl FromNat for Principal {
     #[inline(always)]
-    fn from_nat(input: Nat) -> Principal {
+    fn from_nat(input: Nat) -> Result<Principal, String> {
         let be_bytes = input.0.to_bytes_be();
         let be_bytes_len = be_bytes.len();
+        if be_bytes_len > 29 {
+            return Err("Invalid Nat".to_string());
+        }
         let padding_bytes = if be_bytes_len > 10 && be_bytes_len < 29 {
             29 - be_bytes_len
         } else if be_bytes_len < 10 {
@@ -187,7 +190,7 @@ impl FromNat for Principal {
         };
         let mut p_slice = vec![0u8; padding_bytes];
         p_slice.extend_from_slice(&be_bytes);
-        Principal::from_slice(&p_slice)
+        Ok(Principal::from_slice(&p_slice))
     }
 }
 

--- a/magic_bridge/ic/src/dip20_proxy/src/api/mint.rs
+++ b/magic_bridge/ic/src/dip20_proxy/src/api/mint.rs
@@ -25,6 +25,11 @@ pub async fn mint(token_id: TokendId, nonce: Nonce, payload: Vec<Nat>) -> TxRece
     let erc20_addr_hex = ERC20_ADDRESS_ETH.trim_start_matches("0x");
     let erc20_addr_pid = Principal::from_slice(&hex::decode(erc20_addr_hex).unwrap());
 
+    let to = match Principal::from_nat(payload[0].clone()) {
+        Ok(canister) => canister,
+        Err(msg) => return Err(TxError::Other(msg)),
+    };
+
     let msg_hash = Message.calculate_hash(IncomingMessageHashParams {
         from: erc20_addr_pid.to_nat(),
         to: self_id.to_nat(),
@@ -62,7 +67,6 @@ pub async fn mint(token_id: TokendId, nonce: Nonce, payload: Vec<Nat>) -> TxRece
     STATE.with(|s| s.update_incoming_message_status(msg_hash.clone(), MessageStatus::Consuming));
 
     let amount = Nat::from(payload[2].0.clone());
-    let to = Principal::from_nat(payload[1].clone());
 
     match token_id.mint(to, amount).await {
         Ok(txn_id) => {

--- a/magic_bridge/ic/src/dip20_proxy/src/common/types.rs
+++ b/magic_bridge/ic/src/dip20_proxy/src/common/types.rs
@@ -28,6 +28,7 @@ pub enum FactoryError {
     EncodeError,
     CodeAlreadyInstalled,
     InstallCodeError,
+    InvalidCanisterId,
 }
 
 #[derive(Clone, CandidType, Deserialize, Eq, PartialEq, Debug)]

--- a/magic_bridge/ic/src/dip20_proxy/src/common/utils.rs
+++ b/magic_bridge/ic/src/dip20_proxy/src/common/utils.rs
@@ -17,6 +17,7 @@ impl fmt::Display for FactoryError {
             FactoryError::EncodeError => write!(f, "EncodeError"),
             FactoryError::CodeAlreadyInstalled => write!(f, "CodeAlreadyInstalled"),
             FactoryError::InstallCodeError => write!(f, "InstallCodeError"),
+            FactoryError::InvalidCanisterId => write!(f, "InvalidCanisterId"),
         }
     }
 }

--- a/magic_bridge/ic/src/dip20_proxy/src/proxy.rs
+++ b/magic_bridge/ic/src/dip20_proxy/src/proxy.rs
@@ -167,14 +167,17 @@ impl ToNat for Principal {
 }
 
 pub trait FromNat {
-    fn from_nat(input: Nat) -> Principal;
+    fn from_nat(input: Nat) -> Result<Principal, String>;
 }
 
 impl FromNat for Principal {
     #[inline(always)]
-    fn from_nat(input: Nat) -> Principal {
+    fn from_nat(input: Nat) -> Result<Principal, String> {
         let be_bytes = input.0.to_bytes_be();
         let be_bytes_len = be_bytes.len();
+        if be_bytes_len > 29 {
+            return Err("Invalid Nat".to_string());
+        }
         let padding_bytes = if be_bytes_len > 10 && be_bytes_len < 29 {
             29 - be_bytes_len
         } else if be_bytes_len < 10 {
@@ -184,7 +187,7 @@ impl FromNat for Principal {
         };
         let mut p_slice = vec![0u8; padding_bytes];
         p_slice.extend_from_slice(&be_bytes);
-        Principal::from_slice(&p_slice)
+        Ok(Principal::from_slice(&p_slice))
     }
 }
 
@@ -426,6 +429,19 @@ mod tests {
         assert_eq!(
             erc20_addr_pid.to_string(),
             "6iiev-lyvwz-q7nu7-5tj7n-r3kmr-c6m7u-kumzc-eipy"
+        );
+    }
+
+    #[test]
+    fn test_principal_from_nat() {
+        let eth_address_as_nat =
+            Nat::from_str("1118288024408649503359660893691376548931478070077").unwrap();
+
+        let principal = Principal::from_nat(eth_address_as_nat.clone()).unwrap();
+
+        assert_eq!(
+            principal.to_string(),
+            String::from("t2i2h-eqaaa-aaaaa-aaaaa-bq7by-tzdmi-ryasy-aj22p-4qrgf-evilg-rt2")
         );
     }
 

--- a/magic_bridge/ic/src/magic_bridge/magic_bridge.did
+++ b/magic_bridge/ic/src/magic_bridge/magic_bridge.did
@@ -13,6 +13,7 @@ type CreateCanisterParam = record {
   symbol : text;
 };
 type FactoryError = variant {
+  InvalidCanisterId;
   CanisterStatusNotAvailableError;
   CreateCanisterError;
   EncodeError;

--- a/magic_bridge/ic/src/magic_bridge/src/api/create.rs
+++ b/magic_bridge/ic/src/magic_bridge/src/api/create.rs
@@ -1,5 +1,6 @@
 use crate::api::admin::is_authorized;
 use crate::factory::{FromNat, CAP_ADDRESS};
+use crate::types::FactoryError;
 use crate::{
     factory::{CreateCanisterParam, Factory},
     magic::STATE,
@@ -19,7 +20,10 @@ use std::str;
 async fn create(token_type: TokenType, payload: Vec<Nat>) -> MagicResponse {
     let self_id = ic::id();
     let caller = ic::caller();
-    let eth_addr = Principal::from_nat(payload[0].clone());
+    let eth_addr = match Principal::from_nat(payload[0].clone()) {
+        Ok(canister) => canister,
+        Err(_msg) => return Err(FactoryError::InvalidCanisterId),
+    };
 
     let canister_exits = STATE.with(|s| s.get_canister(eth_addr));
 

--- a/magic_bridge/ic/src/magic_bridge/src/factory.rs
+++ b/magic_bridge/ic/src/magic_bridge/src/factory.rs
@@ -11,14 +11,17 @@ pub const DIP20_WASM: &[u8] = include_bytes!("../../wasm/dip20/token-opt.wasm");
 // const DIP721_WASM: &[u8] = include_bytes!("../../wasm/dip721/nft-opt.wasm");
 
 pub trait FromNat {
-    fn from_nat(input: Nat) -> Principal;
+    fn from_nat(input: Nat) -> Result<Principal, String>;
 }
 
 impl FromNat for Principal {
     #[inline(always)]
-    fn from_nat(input: Nat) -> Principal {
+    fn from_nat(input: Nat) -> Result<Principal, String> {
         let be_bytes = input.0.to_bytes_be();
         let be_bytes_len = be_bytes.len();
+        if be_bytes_len > 29 {
+            return Err("Invalid Nat".to_string());
+        }
         let padding_bytes = if be_bytes_len > 10 && be_bytes_len < 29 {
             29 - be_bytes_len
         } else if be_bytes_len < 10 {
@@ -28,7 +31,7 @@ impl FromNat for Principal {
         };
         let mut p_slice = vec![0u8; padding_bytes];
         p_slice.extend_from_slice(&be_bytes);
-        Principal::from_slice(&p_slice)
+        Ok(Principal::from_slice(&p_slice))
     }
 }
 
@@ -200,5 +203,24 @@ impl Factory {
         });
 
         Ok(canister_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_principal_from_nat() {
+        let eth_address_as_nat =
+            Nat::from_str("1118288024408649503359660893691376548931478070077").unwrap();
+
+        let principal = Principal::from_nat(eth_address_as_nat.clone()).unwrap();
+
+        assert_eq!(
+            principal.to_string(),
+            String::from("t2i2h-eqaaa-aaaaa-aaaaa-bq7by-tzdmi-ryasy-aj22p-4qrgf-evilg-rt2")
+        );
     }
 }

--- a/magic_bridge/ic/src/magic_bridge/src/types.rs
+++ b/magic_bridge/ic/src/magic_bridge/src/types.rs
@@ -22,6 +22,7 @@ pub enum FactoryError {
     EncodeError,
     CodeAlreadyInstalled,
     InstallCodeError,
+    InvalidCanisterId,
 }
 #[derive(CandidType, Deserialize, Debug)]
 


### PR DESCRIPTION
# Description
 
 - Improve implementation `Principal::from_nat(nat: Nat)` now this function return Result<Principal, String> and its Error when Nat slice is longer than 29, this prevents a posible panic!